### PR TITLE
Add negative testcase for FRQ1001-N1

### DIFF
--- a/requirements/Requirements_Spec.tex
+++ b/requirements/Requirements_Spec.tex
@@ -44,7 +44,7 @@
 % --- CRAWLER (1xxx) ---
 \multicolumn{3}{l}{\textbf{\textit{Crawler (1000 Series)}}} \\
 \midrule
-FRQ-1001 & The system shall crawl web pages starting from a given seed URL. &  TC-FRQ-1001\\
+FRQ-1001 & The system shall crawl web pages starting from a given seed URL. &  TC-FRQ-1001 - TC-FRQ-1001-N1 \\
 FRQ-1002 & The system shall follow internal links recursively. & TC-FRQ-1001\\
 
 

--- a/testing/Test_Cases.tex
+++ b/testing/Test_Cases.tex
@@ -56,6 +56,40 @@ Given a set of linked URLs, Verify that the crawler starts from a seed URL then 
   \item No errors occur.
   \item The search index surrogate contains entries from the seed URL page and all other linked pages in recursively order.
 \end{itemize}
+% ==========================================================
+
+\section{Test Case: TC-FRQ-1001-N1}
+
+\subsection*{Related Requirements}
+FRQ-1001
+
+\subsection*{Description}
+Verify that the crawler ignores a seed URL whose domain is not in the whitelist.
+
+\subsection*{Preconditions}
+\begin{itemize}
+  \item The crawler system is operational.
+  \item A domain whitelist configuration exists.
+  \item The domain of the provided seed URL is not included in the whitelist.
+  \item The current state of the search index can be observed.
+\end{itemize}
+
+\subsection*{Test Steps}
+\begin{enumerate}
+  \item Record the current state of the search index.
+  \item Issue a start crawl command using a seed URL whose domain is not part of the whitelist.
+  \item Record the state of the search index after the command completes.
+\end{enumerate}
+
+\subsection*{Expected Results}
+\begin{itemize}
+  \item The crawl request is terminated immediately.
+  \item No crawling process or crawl workflow is initiated.
+  \item No HTTP requests are sent.
+  \item No URLs are enqueued for crawling.
+  \item The state of the search index remains unchanged.
+  \item The command completes without errors.
+\end{itemize}
 
 % ==========================================================
 


### PR DESCRIPTION
For the MVP, this negative test case checks that the crawler ignores seed URLs that are not in the whitelist.
If the URL is not allowed, the crawler stops immediately and does not start crawling or indexing.
This keeps the crawler behavior simple for early development.